### PR TITLE
Change homepage title colors from green to black

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -15,7 +15,7 @@
 
 .section h2 {
   font-size: 2rem;
-  color: var(--ifm-color-primary);
+  color: #000000;
   font-weight: 700;
   margin-bottom: 1rem;
 }
@@ -54,7 +54,7 @@
 
 .card h3 {
   font-size: 1.5rem;
-  color: var(--ifm-color-primary-lightest2);
+  color: #000000;
   margin-bottom: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
• Changed section h2 title color from green to black (#000000) for better readability
• Updated card h3 title colors from green to black (#000000) for improved visual contrast
• Enhanced overall homepage text visibility and accessibility

## Test plan
- [ ] Run `npm start` to verify homepage displays correctly
- [ ] Check that section heading "Explore Topics" now appears in black
- [ ] Verify card titles (Getting Started, Features & Tools, etc.) display in black
- [ ] Confirm readability and visual contrast improvements

🤖 Generated with [Claude Code](https://claude.ai/code)