### PR TITLE
Change "Help Center" label to "Get Started" and hide "Get Started" button from homepage

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -97,7 +97,7 @@ const config = {
             type: 'docSidebar',
             sidebarId: 'tutorialSidebar',
             position: 'left',
-            label: 'Help Center',
+            label: 'Get Started',
           },
 
           {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -24,14 +24,14 @@ function HomepageHeader() {
               Step-by-step guides to help you accomplish every task with ease.
             </p>
 
-            <div className="hero-buttons">
+            {/* <div className="hero-buttons">
               <Link
                   className="hero-button button--secondary"
                   to="/get-started/Welcome"
               >
                 <span>Get Started</span>
               </Link>
-            </div>
+            </div> */}
           </div>
         </div>
       </header>


### PR DESCRIPTION
1.Renamed the "Help Center" label to "Get Started", since both the label and the "Get Started" button navigated to the same Welcome Details.
2.Hidden the "Get Started" button from the homepage, since it navigated to the same Welcome Details page as the updated label.